### PR TITLE
Added graph showing if usernames are provided

### DIFF
--- a/components/UserInformation.vue
+++ b/components/UserInformation.vue
@@ -41,7 +41,17 @@ export default {
   methods: {
     sendUsernameData() {
       this.$emit('calculateData', { githubUsername: this.githubUsername, gitlabUsername: this.gitlabUsername });
+    },
+    sendUsernameIfProvided() {
+      this.githubUsername = this.$route.query.githubUsername
+      this.gitlabUsername = this.$route.query.gitlabUsername
+      if (this.githubUsername && this.gitlabUsername) {
+        this.sendUsernameData()
+      }
     }
-  }
+  },
+  beforeMount() {
+    this.sendUsernameIfProvided()
+  },
 }
 </script>


### PR DESCRIPTION
I added the "sendUsernameData" call if both GitHub and GitLab usernames are provided in the route.

These changes can be very useful because I would like to embed your chart in my github/gitlab profile README.
In the README GitHub and GitLab users can only render images. 
So this is my workaround: if these changes are approved all GitHub and GitLab users can show their merged commit by making a screenshot of your contra web app. This can be automatically done with some services like [site-shot](https://www.site-shot.com/) that provide API. 

So we can embed the contra screen using something like:
```markdown
[ZappaBoy's Contribution Graph](https://api.site-shot.com/?url=https://contra-psi.vercel.app?githubUsername=ZappaBoy&gitlabUsername=ZappaBoy&userkey=site-shot-api-key)
```

Note that I made these changes in a couple of minutes so I can't be sure that everything works perfectly. Maybe you can test that all works before confirming the merge.

I hope my idea can help all, this can be a very good solution if everything I said works.